### PR TITLE
Refactor Teaser Styles for Mobile-First focus

### DIFF
--- a/src/components/NuxtTeaser.vue
+++ b/src/components/NuxtTeaser.vue
@@ -84,6 +84,9 @@ const props = defineProps<Teaser>();
 
 /* Default styles for the main teaser container */
 .teaser-container {
+  display: block; /* Ensure it behaves as a block-level element */
+  width: 100%; /* Explicitly take full width for mobile-first */
+  box-sizing: border-box; /* Include padding and border in the element's total width and height */
   padding: var(--teaser-padding); /* Uses the base padding unit */
   border: 1px solid var(--color-border-default); /* Default border styling */
   /* margin-bottom is important for spacing between teasers. 
@@ -143,15 +146,6 @@ const props = defineProps<Teaser>();
   gap: 0.5em; /* Gap between grid cells */
 }
 
-.medium img {
-  width: 100%; /* Image takes full width of its grid area */
-  height: auto; /* Maintains aspect ratio */
-  max-width: 200px; /* Maximum width for the image in medium cards */
-  grid-area: c; /* Assigns image to the 'c' grid area */
-  align-self: center; /* Vertically centers the image in its grid cell */
-  border-radius: var(--teaser-border-radius); /* Rounded corners for the image */
-}
-
 /* Specific title styling for medium variant */
 .medium h3 {
   font-size: 1.1rem; /* Overrides default title font-size for medium cards */
@@ -178,13 +172,21 @@ const props = defineProps<Teaser>();
   grid-template-rows: auto 1fr; /* Title row auto, content row takes remaining space */
 }
 
+/* Combined image styles for medium and small variants */
+.medium img, .small img {
+  grid-area: c;
+  width: 100%;
+  height: auto;
+  align-self: center;
+  border-radius: var(--teaser-border-radius);
+}
+
+.medium img {
+  max-width: 200px; /* Maximum width for the image in medium cards */
+}
+
 .small img {
-  grid-area: c; /* Assigns image to the 'c' grid area */
-  width: 100%; /* Image takes full width of its grid area */
-  height: auto; /* Maintains aspect ratio */
-  max-width: 120px; /* Maximum width for the image in small cards */
-  align-self: center; /* Vertically centers the image */
-  border-radius: var(--teaser-border-radius); /* Rounded corners */
+  max-width: 100px; /* Maximum width for the image in small cards - adjusted to be "tiny" */
 }
 
 /* Specific title styling for small variant */

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,7 +26,9 @@ Astro.response.headers.set(
 <Layout title="just Vue">
   <main>
     <h2>Luminous news</h2>
-    {teasers.map((teaser) => <NuxtTeaser {...teaser} />)}
+    <div class="teaser-grid-container">
+      {teasers.map((teaser) => <NuxtTeaser {...teaser} />)}
+    </div>
     {/* JS comment syntax will be skipped on build, so use for docs or TODO  */}
     {/* todo: add wrapper and handle bundles explicitly */}
   </main>
@@ -36,7 +38,24 @@ Astro.response.headers.set(
   main {
     margin: auto;
     padding: 1.5rem;
-    max-width: 60ch;
+    max-width: 60ch; /* Default max-width */
+  }
+
+  .teaser-grid-container {
+    /* Default is single column, which divs naturally do.
+       Or, be explicit for clarity if other flex/grid styles might interfere: */
+    display: block; /* Or display: flex; flex-direction: column; */
+  }
+
+  @media (min-width: 1200px) { /* Adjust breakpoint as needed for "large desktop" */
+    main {
+      max-width: 120ch; /* Increase max-width to accommodate two columns. Adjust as needed. */
+    }
+    .teaser-grid-container {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr); /* Two equal columns */
+      gap: 1.5rem; /* Adjust gap as desired, matches main padding */
+    }
   }
 
   h2 {


### PR DESCRIPTION
Another Jules effort at restoring some of baseline prior to first testing iterations. 
Step by step "tasklist" into 6 minutes of work

**Details below:**
This commit refactors the teaser component styles and related page markup to meet new responsive design requirements.

Key changes:
- Implemented mobile-first styling for `NuxtTeaser.vue`. Teasers now fill the width on mobile by default.
- Ensured titles are full-width across all teaser types.
- Big teaser images now span the full width of the teaser.
- Medium teasers feature a modestly sized image (200px) to the right of the lead text, using CSS Grid for layout.
- Small teasers have a tiny image (100px) and smaller font sizes for title and lead.
- Introduced a two-column layout for teasers on large desktop screens (>=1200px) by updating `src/pages/index.astro` with a grid container and adjusting the main content width.
- Consolidated and cleaned up CSS in `NuxtTeaser.vue`, removing redundancies and ensuring consistent use of variables.
- Minimized the use of explicit media queries, relying on mobile-first principles and CSS Grid's inherent responsiveness.