### PR TITLE
Add ESLint configuration file

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,30 @@
+import js from "@eslint/js";
+import eslintPluginAstro from 'eslint-plugin-astro';
+import tseslint from 'typescript-eslint';
+import pluginVue from 'eslint-plugin-vue';
+
+export default [
+  // ESLint recommended rules
+  js.configs.recommended,
+
+  // Astro config
+  ...eslintPluginAstro.configs.recommended, // Using .recommended for v1.3.1 ESM
+
+  // TypeScript config
+  ...tseslint.configs.recommended,
+
+  // Vue config
+  ...pluginVue.configs['flat/recommended'],
+
+  {
+    files: ['**/*.vue'],
+    languageOptions: {
+      parserOptions: {
+        parser: tseslint.parser,
+      },
+    },
+  },
+  {
+    ignores: ['.astro/', 'dist/']
+  }
+];

--- a/test_file.txt
+++ b/test_file.txt
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
ESLint was failing because it couldn't find the configuration file. 
This commit adds a basic eslint.config.js file with support for Astro, Vue, and TypeScript.

The new configuration enables recommended rules for ESLint, Astro, Vue, and TypeScript. Running `npm run lint` now correctly uses this configuration file. This resolves the issue of ESLint not finding its configuration. Further work can be done to address the linting errors reported by the new setup.

> ESLint reported 100 problems (74 errors, 26 warnings), which are expected with the new setup and can be addressed separately.

large chunk from guards files, as inital task added them to ignore file, then somehow "lost" file during bracnh creation leading to dual extra tasks to get back here...